### PR TITLE
Step9:  LoggingFilter, QueueTokenInterceptor 구현

### DIFF
--- a/src/main/java/com/hhplus/concertreservation/common/config/FilterConfig.java
+++ b/src/main/java/com/hhplus/concertreservation/common/config/FilterConfig.java
@@ -1,5 +1,6 @@
-package com.hhplus.concertreservation.support.api.filter;
+package com.hhplus.concertreservation.common.config;
 
+import com.hhplus.concertreservation.support.api.filter.LoggingFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/hhplus/concertreservation/common/config/WebConfig.java
+++ b/src/main/java/com/hhplus/concertreservation/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.hhplus.concertreservation.common.config;
+
+import com.hhplus.concertreservation.support.api.intercepter.QueueTokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final QueueTokenInterceptor queueTokenInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(queueTokenInterceptor)
+                .addPathPatterns("/api/v1/payments/**")
+                .addPathPatterns("/api/v1/concerts/**");
+    }
+}

--- a/src/main/java/com/hhplus/concertreservation/concert/domain/service/ConcertService.java
+++ b/src/main/java/com/hhplus/concertreservation/concert/domain/service/ConcertService.java
@@ -13,11 +13,13 @@ import com.hhplus.concertreservation.concert.domain.repository.ConcertReader;
 import com.hhplus.concertreservation.concert.domain.repository.ConcertWriter;
 import com.hhplus.concertreservation.support.domain.exception.CoreException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConcertService {
@@ -54,6 +56,9 @@ public class ConcertService {
         final ConcertReservation concertReservation = ConcertReservation.create(command, totalPrice, timeProvider.now());
         final ConcertReservation savedConcertReservation = concertWriter.save(concertReservation);
 
+        log.info("임시 예약 완료: 콘서트 ID = {}, 예약 좌석 수 = {}, 총 가격 = {}",
+                command.concertId(), concertSeats.size(), totalPrice);
+
         return new ConcertReservationInfo(savedConcertReservation, savedConcertSeats);
     }
 
@@ -76,6 +81,9 @@ public class ConcertService {
 
         concertWriter.save(concertReservation);
         concertWriter.saveAll(concertSeats);
+
+        log.info("예약 확정 완료: 예약 ID = {}, 예약 좌석 ID = {}",
+                reservationId, concertReservation.getSeatIds());
     }
 
 
@@ -132,5 +140,8 @@ public class ConcertService {
 
         concertWriter.save(concertReservation);
         concertWriter.saveAll(concertSeats);
+
+        log.info("임시 예약 취소 완료: 예약 ID = {}, 취소된 좌석 ID = {}",
+                reservationId, concertReservation.getSeatIds());
     }
 }

--- a/src/main/java/com/hhplus/concertreservation/payment/application/usecase/PayReservationUseCase.java
+++ b/src/main/java/com/hhplus/concertreservation/payment/application/usecase/PayReservationUseCase.java
@@ -11,8 +11,10 @@ import com.hhplus.concertreservation.queue.domain.service.WaitingQueueService;
 import com.hhplus.concertreservation.support.domain.exception.CoreException;
 import com.hhplus.concertreservation.user.domain.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class PayReservationUseCase {
@@ -39,6 +41,8 @@ public class PayReservationUseCase {
 
         // 대기열 만료
         waitingQueueService.expireQueue(token);
+
+        log.info("결제 완료: 사용자 ID = {}, 예약 ID = {}, 결제 ID = {}", userId, reservationId, payment.getId());
         return payment;
     }
 }

--- a/src/main/java/com/hhplus/concertreservation/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/com/hhplus/concertreservation/payment/presentation/controller/PaymentController.java
@@ -1,10 +1,8 @@
 package com.hhplus.concertreservation.payment.presentation.controller;
 
 
-import com.hhplus.concertreservation.payment.domain.model.enums.PaymentStatus;
 import com.hhplus.concertreservation.payment.application.usecase.PayReservationUseCase;
 import com.hhplus.concertreservation.payment.domain.model.entity.Payment;
-
 import com.hhplus.concertreservation.payment.presentation.dto.request.PaymentRequest;
 import com.hhplus.concertreservation.payment.presentation.dto.response.PaymentResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/hhplus/concertreservation/queue/domain/exception/WaitingQueueErrorType.java
+++ b/src/main/java/com/hhplus/concertreservation/queue/domain/exception/WaitingQueueErrorType.java
@@ -6,6 +6,7 @@ import org.springframework.boot.logging.LogLevel;
 
 public enum WaitingQueueErrorType implements ErrorType {
 
+    WAITING_QUEUE_HEADER_NOT_FOUND(ErrorCode.AUTHENTICATION_ERROR, "대기열 헤더 정보를 찾을 수 없습니다", LogLevel.WARN),
     WAITING_QUEUE_NOT_FOUND(ErrorCode.NOT_FOUND, "해당 대기열 정보를 찾을 수 없습니다", LogLevel.WARN),
     WAITING_QUEUE_EXPIRED(ErrorCode.AUTHORIZATION_ERROR, "대기열이 만료되었습니다", LogLevel.INFO),
     WAITING_QUEUE_NOT_ACTIVATED(ErrorCode.AUTHORIZATION_ERROR, "대기열이 활성상태가 아닙니다", LogLevel.WARN),

--- a/src/main/java/com/hhplus/concertreservation/support/api/filter/FilterConfig.java
+++ b/src/main/java/com/hhplus/concertreservation/support/api/filter/FilterConfig.java
@@ -1,0 +1,17 @@
+package com.hhplus.concertreservation.support.api.filter;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<LoggingFilter> loggingFilter() {
+        FilterRegistrationBean<LoggingFilter> regBean = new FilterRegistrationBean<>();
+        regBean.setFilter(new LoggingFilter());
+        regBean.addUrlPatterns("/*");
+        return regBean;
+    }
+}

--- a/src/main/java/com/hhplus/concertreservation/support/api/filter/LoggingFilter.java
+++ b/src/main/java/com/hhplus/concertreservation/support/api/filter/LoggingFilter.java
@@ -10,6 +10,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @Slf4j
 public class LoggingFilter extends OncePerRequestFilter {
@@ -18,18 +19,27 @@ public class LoggingFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         ContentCachingRequestWrapper httpServletRequest = new ContentCachingRequestWrapper(request);
         ContentCachingResponseWrapper httpServletResponse = new ContentCachingResponseWrapper(response);
-        filterChain.doFilter(httpServletRequest, httpServletResponse);
 
         // request 로깅
         String uri = httpServletRequest.getRequestURI();
         String reqContent = new String(httpServletRequest.getContentAsByteArray());
         log.info("request uri : {}, request body: {}", uri, reqContent);
 
+        // 다음 필터로 요청을 전달
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+
         // response 로깅
         int httpStatus = httpServletResponse.getStatus();
         String resContent = new String(httpServletResponse.getContentAsByteArray());
         httpServletResponse.copyBodyToResponse();
         log.info("response status: {}, response body {}", httpStatus, resContent);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String[] excludePath = {"/swagger-ui", "/v3/api-docs"};
+        String path = request.getRequestURI();
+        return Arrays.stream(excludePath).anyMatch(path::startsWith);
     }
 }
 

--- a/src/main/java/com/hhplus/concertreservation/support/api/filter/LoggingFilter.java
+++ b/src/main/java/com/hhplus/concertreservation/support/api/filter/LoggingFilter.java
@@ -1,0 +1,35 @@
+package com.hhplus.concertreservation.support.api.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+@Slf4j
+public class LoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper httpServletRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper httpServletResponse = new ContentCachingResponseWrapper(response);
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+
+        // request 로깅
+        String uri = httpServletRequest.getRequestURI();
+        String reqContent = new String(httpServletRequest.getContentAsByteArray());
+        log.info("request uri : {}, request body: {}", uri, reqContent);
+
+        // response 로깅
+        int httpStatus = httpServletResponse.getStatus();
+        String resContent = new String(httpServletResponse.getContentAsByteArray());
+        httpServletResponse.copyBodyToResponse();
+        log.info("response status: {}, response body {}", httpStatus, resContent);
+    }
+}
+

--- a/src/main/java/com/hhplus/concertreservation/support/api/intercepter/QueueTokenInterceptor.java
+++ b/src/main/java/com/hhplus/concertreservation/support/api/intercepter/QueueTokenInterceptor.java
@@ -1,0 +1,30 @@
+package com.hhplus.concertreservation.support.api.intercepter;
+
+import com.hhplus.concertreservation.queue.domain.exception.WaitingQueueErrorType;
+import com.hhplus.concertreservation.queue.domain.service.WaitingQueueService;
+import com.hhplus.concertreservation.support.domain.exception.CoreException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class QueueTokenInterceptor implements HandlerInterceptor {
+
+    private final WaitingQueueService waitingQueueService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        final String token = request.getHeader("QUEUE-TOKEN");
+        if (Objects.isNull(token) || token.isEmpty()) {
+            throw new CoreException(WaitingQueueErrorType.WAITING_QUEUE_HEADER_NOT_FOUND, "대기열 토큰 정보를 찾을 수 없습니다");
+        }
+
+        waitingQueueService.checkActivatedQueue(token);
+        return true;
+    }
+}

--- a/src/main/java/com/hhplus/concertreservation/user/domain/service/UserService.java
+++ b/src/main/java/com/hhplus/concertreservation/user/domain/service/UserService.java
@@ -6,8 +6,10 @@ import com.hhplus.concertreservation.user.domain.model.entity.UserPoint;
 import com.hhplus.concertreservation.user.domain.repository.UserReader;
 import com.hhplus.concertreservation.user.domain.repository.UserWriter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -30,13 +32,19 @@ public class UserService {
         checkUserExist(userId);
         final UserPoint userPoint = userReader.getUserPointByUserId(userId);
         userPoint.charge(amount);
-        return userWriter.saveUserPoint(userPoint);
+        final UserPoint savedUserPoint = userWriter.saveUserPoint(userPoint);
+
+        log.info("포인트 충전 완료: 사용자 ID = {}, 충전 금액 = {}", userId, amount);
+        return savedUserPoint;
     }
 
     public UserPoint usePoint(final Long userId, final long amount) {
         checkUserExist(userId);
         final UserPoint userPoint = userReader.getUserPointByUserId(userId);
         userPoint.use(amount);
-        return userWriter.saveUserPoint(userPoint);
+        final UserPoint savedUserPoint = userWriter.saveUserPoint(userPoint);
+
+        log.info("포인트 사용 완료: 사용자 ID = {}, 사용 금액 = {}", userId, amount);
+        return savedUserPoint;
     }
 }

--- a/src/test/java/com/hhplus/concertreservation/support/api/intercepter/QueueTokenInterceptorTest.java
+++ b/src/test/java/com/hhplus/concertreservation/support/api/intercepter/QueueTokenInterceptorTest.java
@@ -1,0 +1,81 @@
+package com.hhplus.concertreservation.support.api.intercepter;
+
+import com.hhplus.concertreservation.queue.domain.exception.WaitingQueueErrorType;
+import com.hhplus.concertreservation.queue.domain.service.WaitingQueueService;
+import com.hhplus.concertreservation.support.domain.exception.CoreException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class QueueTokenInterceptorTest {
+
+    @InjectMocks
+    private QueueTokenInterceptor queueTokenInterceptor;
+
+    @Mock
+    private WaitingQueueService waitingQueueService;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    public void setup() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void 유효한_토큰이라면_에러가_발생하지_않는다() throws Exception {
+        // given
+        String validToken = "valid-token";
+        request.addHeader("QUEUE-TOKEN", validToken);
+        doNothing().when(waitingQueueService).checkActivatedQueue(validToken);
+
+        // when & then
+        assertDoesNotThrow(() ->
+                queueTokenInterceptor.preHandle(request, response, new Object())
+        );
+    }
+
+    @Test
+    void 토큰이_없다면_에러가_발생한다() {
+        // given
+        request.addHeader("QUEUE-TOKEN", "");
+
+        // when & then
+        thenThrownBy(() ->
+                queueTokenInterceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(CoreException.class)
+                .hasMessage("대기열 토큰 정보를 찾을 수 없습니다")
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(WaitingQueueErrorType.WAITING_QUEUE_HEADER_NOT_FOUND);
+    }
+
+    @Test
+    void 토큰이_만료되었다면_에러가_발생한다() {
+        // given
+        String invalidToken = "invalid-token";
+        request.addHeader("QUEUE-TOKEN", invalidToken);
+        doThrow(new CoreException(WaitingQueueErrorType.WAITING_QUEUE_EXPIRED, "대기열 토큰이 만료되었습니다."))
+                .when(waitingQueueService).checkActivatedQueue(invalidToken);
+
+        // when & then
+        thenThrownBy(() ->
+                queueTokenInterceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(CoreException.class)
+                .hasMessage("대기열 토큰이 만료되었습니다.")
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(WaitingQueueErrorType.WAITING_QUEUE_EXPIRED);
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용
- 로깅 필터 구현 [9919d48]
- 대기열 토큰 검증 인터셉터 구현 [bac7559]
- 대기열 토큰 검증 인터셉터 단위 테스트 작성 [5e3fe5a]
- info 로깅 추가 [76bfda3]

### 🌊 의사결정 과정
- 대기열 토큰 검증의 경우 비즈니스 로직이라 판단해 스프링 컨텍스트 안에 있는 인터셉터에서 구현했습니다.
  - 대기열 토큰을 검증은 사용자 포인트 관련 API 제외하고 모두 적용되게 설정했습니다.
- 로깅 필터에서 스웨거 관련 요청/응답 로그는 불필요하다고 판단해 관련 url 제외했습니다! [683f9bb]

### 💬 리뷰 요구사항 & 고민 포인트
- INFO 로그를 찍는 기준이 명확하지 않은 것 같아요! 제가 생각했을 때는 추후 모니터링하거나 통계를 낼 때 사용할 수 있는 정보라고 판단되면 로그를 찍었는데, 보통 어떤 기준으로 INFO 레벨의 로그를 찍나요?